### PR TITLE
Fix tab bar padding

### DIFF
--- a/styles/lists.less
+++ b/styles/lists.less
@@ -16,7 +16,6 @@
     // We want to highlight the background of the list items because we dont know their size.
     &.selected {
       color: @text-color-selected;
-      background-color: 0.05;
       z-index: 15;
       &:before{ display: none; }
     }

--- a/styles/lists.less
+++ b/styles/lists.less
@@ -16,6 +16,7 @@
     // We want to highlight the background of the list items because we dont know their size.
     &.selected {
       color: @text-color-selected;
+      background-color: 0.05;
       z-index: 15;
       &:before{ display: none; }
     }

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -18,6 +18,7 @@ atom-pane:not(.active) {
     background-color: @tab-bar-background-color;
     border-top: 1px solid @base-border-color;
     margin: 0 0 10px 0;
+    padding-left: 80px;
 
     .title;
 


### PR DESCRIPTION
Installing on Atom `1.12.7` renders

<img width="248" alt="screen shot 2016-12-23 at 10 37 55 am" src="https://cloud.githubusercontent.com/assets/974723/21457257/e2769f5a-c8fb-11e6-9b8c-7f0595583e32.png">

The padding added in the PR renders it as

<img width="235" alt="screen shot 2016-12-23 at 10 38 30 am" src="https://cloud.githubusercontent.com/assets/974723/21457266/f6fe7448-c8fb-11e6-9d60-41cd72038ac9.png">
